### PR TITLE
Allow taggin for cloudfront distribution and s3 website

### DIFF
--- a/aws/cloudfront_website/main.tf
+++ b/aws/cloudfront_website/main.tf
@@ -9,6 +9,7 @@ module "bucket" {
   bucket_name    = var.bucket_name
   index_document = var.bucket_index_document
   error_document = var.bucket_error_document
+  tags           = var.tags
 }
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
@@ -69,4 +70,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
       restriction_type = "none"
     }
   }
+
+  tags = var.tags
 }

--- a/aws/cloudfront_website/variables.tf
+++ b/aws/cloudfront_website/variables.tf
@@ -62,3 +62,8 @@ variable "cf_max_ttl" {
 variable "cf_compress" {
   default = true
 }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/aws/s3/website/main.tf
+++ b/aws/s3/website/main.tf
@@ -33,4 +33,6 @@ EOF
     expose_headers  = ["Authorization"]
     max_age_seconds = 3000
   }
+
+  tags = var.tags
 }

--- a/aws/s3/website/variables.tf
+++ b/aws/s3/website/variables.tf
@@ -7,3 +7,8 @@ variable "index_document" {
 variable "error_document" {
   default = "index.html"
 }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
## Summary

- Allow cloudfront and s3 website modules to receive new parameter called tags, which will tag the resources deployed